### PR TITLE
Feat/content only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+    // editor
+    "editor.wordWrap": "on",
+    "editor.fontSize": 18,
+    "editor.lineHeight": 30,
+    "editor.tabSize": 2,
+    "editor.bracketPairColorization.enabled": true,
+    "editor.guides.bracketPairs": true,
+    "editor.minimap.enabled": false,
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true,
+  
+    // explorer
+    "explorer.compactFolders": false,
+  
+    // workbench
+    "workbench.editor.enablePreview": false,
+    "workbench.iconTheme": "material-icon-theme",
+    "workbench.colorTheme": "Omni",
+  
+    // prettier
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "prettier.enable": true,
+    "prettier.singleQuote": false,
+    "prettier.tabWidth": 2,
+    "prettier.semi": false,
+  
+    // terminal
+    "terminal.integrated.fontSize": 16,
+    "terminal.integrated.profiles.windows": {
+      "Git Bash": {
+        "source": "Git Bash"
+      }
+    },
+    "terminal.integrated.defaultProfile.windows": "Git Bash",
+    "window.zoomLevel": 0
+  }
+  

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,38 +1,37 @@
 {
-    // editor
-    "editor.wordWrap": "on",
-    "editor.fontSize": 18,
-    "editor.lineHeight": 30,
-    "editor.tabSize": 2,
-    "editor.bracketPairColorization.enabled": true,
-    "editor.guides.bracketPairs": true,
-    "editor.minimap.enabled": false,
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
-  
-    // explorer
-    "explorer.compactFolders": false,
-  
-    // workbench
-    "workbench.editor.enablePreview": false,
-    "workbench.iconTheme": "material-icon-theme",
-    "workbench.colorTheme": "Omni",
-  
-    // prettier
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "prettier.enable": true,
-    "prettier.singleQuote": false,
-    "prettier.tabWidth": 2,
-    "prettier.semi": false,
-  
-    // terminal
-    "terminal.integrated.fontSize": 16,
-    "terminal.integrated.profiles.windows": {
-      "Git Bash": {
-        "source": "Git Bash"
-      }
-    },
-    "terminal.integrated.defaultProfile.windows": "Git Bash",
-    "window.zoomLevel": 0
-  }
-  
+  // editor
+  "editor.wordWrap": "on",
+  "editor.fontSize": 18,
+  "editor.lineHeight": 30,
+  "editor.tabSize": 2,
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": true,
+  "editor.minimap.enabled": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+
+  // explorer
+  "explorer.compactFolders": false,
+
+  // workbench
+  "workbench.editor.enablePreview": false,
+  "workbench.iconTheme": "material-icon-theme",
+  "workbench.colorTheme": "Omni",
+
+  // prettier
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.enable": true,
+  "prettier.singleQuote": false,
+  "prettier.tabWidth": 2,
+  "prettier.semi": false,
+
+  // terminal
+  "terminal.integrated.fontSize": 16,
+  "terminal.integrated.profiles.windows": {
+    "Git Bash": {
+      "source": "Git Bash"
+    }
+  },
+  "terminal.integrated.defaultProfile.windows": "Git Bash",
+  "window.zoomLevel": 0
+}

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Because we love a clean layout, we can toggle (show/hide) view of
 
 by pressing `ctrl+esc`
 
+![Content only preview](.github/content-only.gif)
+
 ---
 
 ## Slide Presentation
 
 You can use this app as a slide presentation.
+
+![Slides preview](.github/slides.gif)
 
 ### 🤔 How?
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 Inject some JS/CSS to customize Notion ;)
 
+---
+
+<p align="center">
+<a href="#how-to-build">How to build</a>&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="#features">Features</a>
+&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="#contact">Contact</a>
+&nbsp;&nbsp;&nbsp;&nbsp;
+</p>
+
 ![Preview](.github/preview.png)
 
 ---
 
-## 4 Steps to use it.
+## How to build
 
 1. Install
 
@@ -25,8 +35,6 @@ yarn package
 
 4. Put your Notion in Dark Mode ;)
 
----
-
 # Features
 
 ## Content Only
@@ -41,7 +49,7 @@ by pressing `ctrl+esc`
 
 ---
 
-## 📽 Slide Presentation
+## Slide Presentation
 
 You can use this app as a slide presentation.
 
@@ -73,11 +81,10 @@ Second slide
 Try it!
 ```
 
----
+# Contact
 
-## 🔗 Get more content!
+Mayk Brito
 
-- [Youtube](https://www.youtube.com/maykbrito)
 - [maykbrito.dev](https://maykbrito.dev)
 
 ---

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Because we love a clean layout, we can toggle (show/hide) view of
 
 by pressing `ctrl+esc`
 
-![Content only preview](.github/content-only.gif)
+![Imgur](https://i.imgur.com/NkJz7cn.gif)
 
 ---
 
@@ -55,7 +55,7 @@ by pressing `ctrl+esc`
 
 You can use this app as a slide presentation.
 
-![Slides preview](.github/slides.gif)
+![Slides preview](https://i.imgur.com/9QL2WTy.gif)
 
 ### 🤔 How?
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ yarn package
 
 ---
 
+# Features
+
+## Content Only
+
+Because we love a clean layout, we can toggle (show/hide) view of
+
+- header bar
+- page title & attributes block
+- help button
+
+by pressing `ctrl+esc`
+
+---
+
 ## 📽 Slide Presentation
 
 You can use this app as a slide presentation.
@@ -39,7 +53,7 @@ You can use this app as a slide presentation.
 
 2. Toggle presentation with `SHIFT+ESC`
 
-Try this. 
+Try this.
 
 Create a new Notion page and add code bellow, then hit `SHIFT+ESC` to see the magic.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@electron-forge/maker-zip": "^6.0.0-beta.61",
     "@electron-forge/plugin-webpack": "^6.0.0-beta.61",
     "@marshallofsound/webpack-asset-relocator-loader": "^0.5.0",
-    "electron": "^15.3.0",
+    "electron": "^21",
     "node-loader": "^2.0.0",
     "webpack": "^5.61.0",
     "webpack-cli": "^4.9.1"

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,11 +1,11 @@
-import { app, BrowserWindow, screen, nativeImage } from 'electron'
-import windowStateKeeper from 'electron-window-state'
-import path from 'path'
+import { app, BrowserWindow, screen, nativeImage } from "electron"
+import windowStateKeeper from "electron-window-state"
+import path from "path"
 
-import { assetsPath } from './utils/assets-path'
-import { checkerURL } from './utils/check-url'
+import { assetsPath } from "./utils/assets-path"
+import { checkerURL } from "./utils/check-url"
 
-import './modules/window-manager'
+import "./modules/window-manager"
 
 let win = null
 app.allowRendererProcessReuse = true
@@ -13,22 +13,23 @@ app.allowRendererProcessReuse = true
 async function createWindow() {
   win = new BrowserWindow({
     icon: nativeImage.createFromPath(
-      path.join(assetsPath, 'assets', 'icon.png')
+      path.join(assetsPath, "assets", "icon.png")
     ),
     frame: false,
-    titleBarStyle: 'customButtonsOnHover',
+    titleBarStyle: "customButtonsOnHover",
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY
-    }
+      sandbox: false,
+      preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+    },
   })
 
   adjustWindow(win)
 
-  win.loadURL('https://notion.so')
+  win.loadURL("https://notion.so")
 
-  win.webContents.on('new-window', checkerURL) // add event listener for URL check
+  win.webContents.on("new-window", checkerURL) // add event listener for URL check
 }
 
 function adjustWindow(win) {
@@ -37,7 +38,7 @@ function adjustWindow(win) {
 
   const mainWindowState = windowStateKeeper({
     defaultWidth: dimensions.width,
-    defaultHeight: dimensions.height
+    defaultHeight: dimensions.height,
   })
 
   let { width, height, x, y } = mainWindowState
@@ -60,15 +61,15 @@ if (!isUnicInstance) {
   app
     .whenReady()
     .then(createWindow)
-    .catch(e => console.error(e))
+    .catch((e) => console.error(e))
 }
 
 // Faz com que o programa não inicie várias vezes durante a instalação no windows
-if (require('electron-squirrel-startup')) {
+if (require("electron-squirrel-startup")) {
   app.quit()
 }
 
-app.on('second-instance', () => {
+app.on("second-instance", () => {
   const win = BrowserWindow.getAllWindows()[0]
   if (win.isMinimized()) {
     win.restore()
@@ -77,15 +78,15 @@ app.on('second-instance', () => {
 })
 
 // Quit when all windows are closed.
-app.on('window-all-closed', () => {
+app.on("window-all-closed", () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
+  if (process.platform !== "darwin") {
     app.quit()
   }
 })
 
-app.on('activate', recreateWindow)
+app.on("activate", recreateWindow)
 
 function recreateWindow() {
   // On macOS it's common to re-create a window in the app when the

--- a/src/renderer/modules/content-only/index.js
+++ b/src/renderer/modules/content-only/index.js
@@ -5,6 +5,7 @@ const elementsToHide = [
   '.notion-frame > div.notion-scroller.vertical.horizontal > div:nth-child(2) > div'
 ]
 let notionFrameInitialHeight
+let elementsInitialDisplay = {}
 
 window.addEventListener('keydown', ev => {
   const shortcutKeys = ev.key === 'Escape' && ev.ctrlKey
@@ -17,18 +18,22 @@ window.addEventListener('keydown', ev => {
 const elementDisplay = (element, display) => {
   if (!document.querySelector(element)) return
 
+  if (display === 'initial') {
+    document.querySelector(element).style.display = elementsInitialDisplay[element]
+    return
+  }
+  
+  elementsInitialDisplay[element] = document.querySelector(element).style.display
   document.querySelector(element).style.display = display
 }
 
 const hide = () => {
   elementsToHide.forEach(element => elementDisplay(element, 'none'))
-
-  notionFrameInitialHeight =
-    document.querySelector('.notion-frame').style.height
+  
+  notionFrameInitialHeight = document.querySelector('.notion-frame').style.height
   document.querySelector('.notion-frame').style.height = '100vh'
 }
 const show = () => {
   elementsToHide.forEach(element => elementDisplay(element, 'initial'))
-  document.querySelector('.notion-frame').style.height =
-    notionFrameInitialHeight
+  document.querySelector('.notion-frame').style.height = notionFrameInitialHeight
 }

--- a/src/renderer/modules/content-only/index.js
+++ b/src/renderer/modules/content-only/index.js
@@ -1,0 +1,31 @@
+let showingOnlyContent = false
+const elementsToHide = [
+  '.notion-cursor-listener > div:nth-child(2) > div:nth-child(1)',
+  '.notion-help-button',
+  '.notion-frame > div.notion-scroller.vertical.horizontal > div:nth-child(2) > div'
+]
+let notionFrameInitialHeight
+
+window.addEventListener('keydown', ev => {
+  const shortcutKeys = ev.key === 'Escape' && ev.ctrlKey
+  if (shortcutKeys) {
+    showingOnlyContent = !showingOnlyContent
+    showingOnlyContent ? hide() : show()
+  }
+})
+
+const elementDisplay = (element, display) =>
+  (document.querySelector(element).style.display = display)
+
+const hide = () => {
+  elementsToHide.forEach(element => elementDisplay(element, 'none'))
+
+  notionFrameInitialHeight =
+    document.querySelector('.notion-frame').style.height
+  document.querySelector('.notion-frame').style.height = '100vh'
+}
+const show = () => {
+  elementsToHide.forEach(element => elementDisplay(element, 'initial'))
+  document.querySelector('.notion-frame').style.height =
+    notionFrameInitialHeight
+}

--- a/src/renderer/modules/content-only/index.js
+++ b/src/renderer/modules/content-only/index.js
@@ -14,8 +14,11 @@ window.addEventListener('keydown', ev => {
   }
 })
 
-const elementDisplay = (element, display) =>
-  (document.querySelector(element).style.display = display)
+const elementDisplay = (element, display) => {
+  if (!document.querySelector(element)) return
+
+  document.querySelector(element).style.display = display
+}
 
 const hide = () => {
   elementsToHide.forEach(element => elementDisplay(element, 'none'))

--- a/src/renderer/modules/slides/bg-cover.css
+++ b/src/renderer/modules/slides/bg-cover.css
@@ -12,3 +12,8 @@
   opacity: 1;
   filter: brightness(0.5);
 }
+
+/* image appear in heading 1 only */
+.slides.dark:not(:has([placeholder="Heading 1"])) .slides__cover-image {
+  display: none;
+}

--- a/src/renderer/modules/slides/bg-cover.js
+++ b/src/renderer/modules/slides/bg-cover.js
@@ -1,9 +1,9 @@
 module.exports.backgroundCover = function () {
   let bgImage = document.querySelector(
-    '#notion-app div.notion-scroller.vertical.horizontal img'
+    '#notion-app div.notion-scroller [contenteditable="false"] img[style*="object-fit: cover"]'
   )
 
-  if (bgImage === 'undefined') return
+  if (bgImage === 'undefined' || bgImage === null) return
 
   let imgElement = document.createElement('img')
   imgElement.src = bgImage.src

--- a/src/renderer/modules/slides/bg-cover.js
+++ b/src/renderer/modules/slides/bg-cover.js
@@ -1,13 +1,13 @@
 module.exports.backgroundCover = function () {
   let bgImage = document.querySelector(
-    '#notion-app div.notion-scroller [contenteditable="false"] img[style*="object-fit: cover"]'
+    '#notion-app div.notion-scroller [contenteditable="false"] img[style*="height: 30vh"]'
   )
 
-  if (bgImage === 'undefined' || bgImage === null) return
+  if (bgImage === "undefined" || bgImage === null) return
 
-  let imgElement = document.createElement('img')
+  let imgElement = document.createElement("img")
   imgElement.src = bgImage.src
-  imgElement.classList.add('slides__cover-image')
+  imgElement.classList.add("slides__cover-image")
 
   return imgElement
 }

--- a/src/renderer/modules/slides/get-slides.js
+++ b/src/renderer/modules/slides/get-slides.js
@@ -1,21 +1,21 @@
 module.exports.getSlides = function () {
   const pageContent = [
-    ...document.querySelectorAll('.notion-page-content > div')
+    ...document.querySelectorAll(".notion-page-content > div"),
   ]
-  const newSlides = pageContent.filter(item =>
-    item.classList.contains('notion-divider-block')
+  const newSlides = pageContent.filter((item) =>
+    item.classList.contains("notion-divider-block")
   )
 
-  const newSlide = block => ({
+  const newSlide = (block) => ({
     title: block,
-    blocks: []
+    blocks: [],
   })
 
   let currentSlide
 
   const slides = pageContent
-    .map(block => {
-      const isNewSlide = newSlides.find(slide => slide === block)
+    .map((block) => {
+      const isNewSlide = newSlides.find((slide) => slide === block)
 
       if (isNewSlide) {
         currentSlide = newSlide(block)

--- a/src/renderer/modules/slides/index.js
+++ b/src/renderer/modules/slides/index.js
@@ -1,18 +1,20 @@
-const { getSlides } = require('./get-slides.js')
-const { render, $slide, getMainFrame } = require('./render.js')
+const { getSlides } = require("./get-slides.js")
+const { render, $slide, getMainFrame } = require("./render.js")
 
-const injectCSS = require('../../utils/inject-css')
+const injectCSS = require("../../utils/inject-css")
 
-injectCSS('src', 'renderer', 'modules', 'slides', 'slides.css')
-injectCSS('src', 'renderer', 'modules', 'slides', 'bg-cover.css')
+injectCSS("src", "renderer", "modules", "slides", "slides.css")
+
+injectCSS("src", "renderer", "modules", "slides", "texting.css")
+injectCSS("src", "renderer", "modules", "slides", "bg-cover.css")
 
 let data
 let slideIndex = 0
 let isRunning = false
 let mainFrame
 
-window.addEventListener('keydown', function (ev) {
-  if (ev.key === 'Escape' && ev.shiftKey) {
+window.addEventListener("keydown", function (ev) {
+  if (ev.key === "Escape" && ev.shiftKey) {
     isRunning ? hide() : show()
     isRunning = !isRunning
   }
@@ -24,23 +26,23 @@ function show() {
 }
 
 function hide() {
-  mainFrame.style.display = 'none'
-  window.removeEventListener('keydown', control)
+  mainFrame.style.display = "none"
+  window.removeEventListener("keydown", control)
 }
 
 function control(ev) {
   switch (ev.key) {
-    case 'ArrowLeft':
-      move('backward')
+    case "ArrowLeft":
+      move("backward")
       break
-    case 'ArrowRight':
-      move('forward')
+    case "ArrowRight":
+      move("forward")
       break
   }
 }
 
 function move(dir) {
-  var dx = dir === 'backward' ? -1 : 1
+  var dx = dir === "backward" ? -1 : 1
 
   const isLeft = dx === -1
 
@@ -65,7 +67,7 @@ function start() {
   data = getSlides()
   mainFrame = getMainFrame()
 
-  window.addEventListener('keydown', control)
+  window.addEventListener("keydown", control)
 
   render($slide, data[0])
 }

--- a/src/renderer/modules/slides/index.js
+++ b/src/renderer/modules/slides/index.js
@@ -4,7 +4,6 @@ const { render, $slide, getMainFrame } = require("./render.js")
 const injectCSS = require("../../utils/inject-css")
 
 injectCSS("src", "renderer", "modules", "slides", "slides.css")
-
 injectCSS("src", "renderer", "modules", "slides", "texting.css")
 injectCSS("src", "renderer", "modules", "slides", "bg-cover.css")
 
@@ -22,7 +21,7 @@ window.addEventListener("keydown", function (ev) {
 
 function show() {
   mainFrame && mainFrame.parentNode.removeChild(mainFrame)
-  start()
+  start(slideIndex)
 }
 
 function hide() {
@@ -69,5 +68,15 @@ function start() {
 
   window.addEventListener("keydown", control)
 
-  render($slide, data[0])
+  prepareSlideWrapper()
+  render($slide, data[slideIndex])
+}
+
+function prepareSlideWrapper() {
+  const notionPageContentStyles = document
+    .querySelector("#notion-app main .notion-page-content")
+    .getAttribute("style")
+  $slide.classList.add("notion-page-content")
+  $slide.setAttribute("style", notionPageContentStyles)
+  $slide.setAttribute("id", "slide-inner")
 }

--- a/src/renderer/modules/slides/render.js
+++ b/src/renderer/modules/slides/render.js
@@ -1,5 +1,5 @@
-const { createMainFrame } = require('./main-frame.js')
-const { createSlideElement } = require('./slide-element.js')
+const { createMainFrame } = require("./main-frame.js")
+const { createSlideElement } = require("./slide-element.js")
 
 const $slide = createSlideElement()
 
@@ -13,11 +13,11 @@ module.exports.getMainFrame = () => {
 }
 
 module.exports.render = ($slide, currentSlide) => {
-  $slide.innerHTML = ''
+  $slide.innerHTML = ""
   if (!currentSlide) return
-  currentSlide.blocks.forEach(block => {
+  currentSlide.blocks.forEach((block) => {
     const buildBlock = block.cloneNode(true)
-    buildBlock.classList.add('appear')
+    buildBlock.classList.add("appear")
     $slide.appendChild(buildBlock)
   })
 }

--- a/src/renderer/modules/slides/render.js
+++ b/src/renderer/modules/slides/render.js
@@ -15,9 +15,10 @@ module.exports.getMainFrame = () => {
 module.exports.render = ($slide, currentSlide) => {
   $slide.innerHTML = ""
   if (!currentSlide) return
-  currentSlide.blocks.forEach((block) => {
+
+  for (let block of currentSlide.blocks) {
     const buildBlock = block.cloneNode(true)
     buildBlock.classList.add("appear")
     $slide.appendChild(buildBlock)
-  })
+  }
 }

--- a/src/renderer/modules/slides/slides.css
+++ b/src/renderer/modules/slides/slides.css
@@ -1,12 +1,5 @@
-/* slides */
 .slides.dark.notion-frame {
-  /* background-color: var(--dark-2) !important; */
-
   width: 100%;
-  height: 100vh;
-  aspect-ratio: 16/9;
-  padding-block: 3.125em calc(100vh / 10);
-  padding-inline: 1.875em;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -18,11 +11,13 @@
   background-color: white !important;
 }
 
-.slides > div {
-  /* padding: 2rem 4rem 0; */
-  width: 90%;
-  max-width: 800px;
-  margin: 0 auto;
+.slides #slide-inner {
+  width: 90% !important;
+  max-width: 800px !important;
+  margin: 0 auto !important;
+  padding-bottom: 10vh !important;
+  padding-left: calc(0px + env(safe-area-inset-left)) !important;
+  padding-right: calc(0px + env(safe-area-inset-right)) !important;
 }
 
 .slides > div > div {

--- a/src/renderer/modules/slides/slides.css
+++ b/src/renderer/modules/slides/slides.css
@@ -1,6 +1,17 @@
 /* slides */
 .slides.dark.notion-frame {
-  background-color: var(--dark-2) !important;
+  /* background-color: var(--dark-2) !important; */
+
+  width: 100%;
+  height: 100vh;
+  aspect-ratio: 16/9;
+  padding-block: 3.125em calc(100vh / 10);
+  padding-inline: 1.875em;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #05080d !important;
 }
 
 .slides.notion-frame {
@@ -8,7 +19,10 @@
 }
 
 .slides > div {
-  padding: 2rem 4rem 0;
+  /* padding: 2rem 4rem 0; */
+  width: 90%;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .slides > div > div {

--- a/src/renderer/modules/slides/texting.css
+++ b/src/renderer/modules/slides/texting.css
@@ -1,0 +1,84 @@
+/* h1 */
+.slides .capa > div {
+  max-width: 1000px !important;
+}
+
+.slides:has([placeholder="Heading 1"]) {
+  text-align: center !important;
+}
+
+.slides [placeholder="Heading 1"] {
+  font-size: 3em !important;
+  line-height: 1.2 !important;
+  line-height: 1 !important;
+}
+
+.slides [placeholder="Heading 1"]::after {
+  display: block !important;
+  content: "";
+  width: 1.25em !important;
+  height: 0.125em !important;
+  background: var(--primary);
+  border-radius: 4em !important;
+  margin: 0.225em auto 0.3875em !important;
+}
+
+/* h2 */
+.slides [placeholder="Heading 2"] {
+  font-size: 1em !important;
+  margin-bottom: 1em !important;
+  line-height: 1.6 !important;
+}
+
+.slides [placeholder="Heading 2"]::after {
+  content: "";
+  display: block;
+  background: var(--primary);
+  height: 0.2em;
+  width: 1.875em;
+  border-radius: 10px;
+  margin-top: 0.3125em;
+  margin-bottom: 1.25em;
+}
+
+/* p */
+.slides .notion-text-block > div > div > div {
+  font-size: 1.125em !important;
+  line-height: 1.6 !important;
+  margin-inline: 0 !important;
+}
+
+/* list */
+.md ul {
+  list-style: none;
+}
+
+.slides .notion-bulleted_list-block {
+  margin-top: 1.5em !important;
+}
+
+.slides .notion-bulleted_list-block [placeholder="List"] {
+  font-size: 1.375em !important;
+  line-height: 1.2 !important;
+  /* margin-bottom: 0.2em !important; */
+}
+
+.slides .notion-bulleted_list-block .notion-text-block {
+  font-size: 1em !important;
+  line-height: 1.4 !important;
+  opacity: 0.7;
+}
+
+.slides .notion-bulleted_list-block > div > div:nth-child(1) div::before {
+  content: "";
+  display: inline-block;
+  width: 0.3375em !important;
+  height: 0.3375em !important;
+  border-radius: 50%;
+  background-color: var(--primary);
+  border: 2px solid black;
+  margin-right: 0.625em;
+  /* margin-left: -1.125em; */
+  /* transform: translateY(-0.1em); */
+  display: block !important;
+}

--- a/src/renderer/modules/slides/texting.css
+++ b/src/renderer/modules/slides/texting.css
@@ -1,8 +1,4 @@
 /* h1 */
-.slides .capa > div {
-  max-width: 1000px !important;
-}
-
 .slides:has([placeholder="Heading 1"]) {
   text-align: center !important;
 }
@@ -49,10 +45,6 @@
 }
 
 /* list */
-.md ul {
-  list-style: none;
-}
-
 .slides .notion-bulleted_list-block {
   margin-top: 1.5em !important;
 }
@@ -78,7 +70,5 @@
   background-color: var(--primary);
   border: 2px solid black;
   margin-right: 0.625em;
-  /* margin-left: -1.125em; */
-  /* transform: translateY(-0.1em); */
   display: block !important;
 }

--- a/src/renderer/preload.js
+++ b/src/renderer/preload.js
@@ -9,4 +9,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   /** slides feat */
   require('./modules/slides/index.js')
+
+  /** content-only feat */
+  require('./modules/content-only')
 })

--- a/src/renderer/styles/style.css
+++ b/src/renderer/styles/style.css
@@ -32,33 +32,12 @@ body.dark #notion-app .notion-sidebar {
   color: #fff !important;
 }
 
-body.dark .notion-scroller > div:nth-child(1) {
+body.dark .notion-scroller>div:nth-child(1) {
   color: #eee !important;
 }
 
-body.dark
-  #notion-app
-  > div
-  > div
-  > div.notion-sidebar-container
-  > div:nth-child(1)
-  > div:nth-child(2)
-  > div
-  > div:nth-child(1),
-body.dark
-  #notion-app
-  > div
-  > div
-  > div.notion-sidebar-container
-  > div:nth-child(1)
-  > div:nth-child(2)
-  > div
-  > div:nth-child(5)
-  > div:nth-child(1)
-  > span
-  > div
-  > div
-  > div:nth-child(2),
+body.dark #notion-app>div>div>div.notion-sidebar-container>div:nth-child(1)>div:nth-child(2)>div>div:nth-child(1),
+body.dark #notion-app>div>div>div.notion-sidebar-container>div:nth-child(1)>div:nth-child(2)>div>div:nth-child(5)>div:nth-child(1)>span>div>div>div:nth-child(2),
 body.dark .notion-topbar {
   color: #fff !important;
   background-color: var(--dark-1) !important;
@@ -69,14 +48,7 @@ body.dark .notion-frame .notion-selectable a {
   background: rgb(43, 43, 43) !important;
 }
 
-body.dark
-  div.notion-overlay-container.notion-default-overlay-container
-  > div:nth-child(2)
-  > div
-  > div:nth-child(2)
-  > div:nth-child(1)
-  > div:nth-child(1)
-  > div:nth-child(3) {
+body.dark div.notion-overlay-container.notion-default-overlay-container>div:nth-child(2)>div>div:nth-child(2)>div:nth-child(1)>div:nth-child(1)>div:nth-child(3) {
   background: transparent !important;
 }
 
@@ -102,7 +74,7 @@ body.dark .notion-scroller::-webkit-scrollbar-track {
   background: var(--dark-1);
 }
 
-body.dark #notion-app .notion-topbar > div > div:nth-child(2) {
+body.dark #notion-app .notion-topbar>div>div:nth-child(2) {
   display: none !important;
 }
 
@@ -114,19 +86,17 @@ body.dark .notion-frame .notion-selectable a {
 
 /* help button */
 
-body.dark
-  #notion-app
-  > div
-  > div.notion-cursor-listener
-  > div.notion-help-button {
+body.dark #notion-app>div>div.notion-cursor-listener>div.notion-help-button {
   background: var(--dark-1) !important;
 }
 
 body.dark .notion-frame,
+.notion-cursor-listener,
 /* float page */
-body.dark .notion-peek-renderer > div > div,
+body.dark .notion-peek-renderer>div>div,
 /* every style that has rgb(47, 52, 55) as bg */
-[style*='rgb(47, 52, 55)'] {
+[style*='rgb(47, 52, 55)'],
+[style*='background: rgb(25, 25, 25)'] {
   background: var(--dark-1) !important;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,23 @@
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.0"
 
-"@electron/get@^1.13.0", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
+"@electron/get@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
+  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^9.6.0"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^3.0.0"
+    global-tunnel-ng "^2.7.1"
+
+"@electron/get@^1.6.0", "@electron/get@^1.9.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"
   integrity sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==
@@ -477,10 +493,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
-"@types/node@^14.6.2":
-  version "14.17.32"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.32.tgz#2ca61c9ef8c77f6fa1733be9e623ceb0d372ad96"
-  integrity sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==
+"@types/node@^16.11.26":
+  version "16.11.65"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.65.tgz#59500b86af757d6fcabd3dec32fecb6e357d7a45"
+  integrity sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==
 
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
@@ -1317,16 +1333,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
 config-chain@^1.1.11:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
@@ -1446,7 +1452,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1811,14 +1817,14 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@^15.3.0:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.0.tgz#f9803c5a05b2dac12efc6d4203492c7e204b4819"
-  integrity sha512-YLzaKCFmSniNlz9+NUTNs7ssPyDc+bYOCYZ0b/D6DjVkOeIFz4SR8EYKqlOc8TcqlDNu18BbWqz6zbJPyAAURg==
+electron@^21:
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.1.0.tgz#7272dfe1a5d6a00fd58d17b26215e541b6ff10dd"
+  integrity sha512-CM5VZpZPtAoPgTPcmEbRaZWXlxGuD5a5DTeAwm0F0F6/k6R3HZAi8vZnE77gwuHK/Qqcinw4/MAbiCwAKh2W+g==
   dependencies:
-    "@electron/get" "^1.13.0"
-    "@types/node" "^14.6.2"
-    extract-zip "^1.0.3"
+    "@electron/get" "^1.14.1"
+    "@types/node" "^16.11.26"
+    extract-zip "^2.0.1"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2046,17 +2052,7 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extract-zip@^1.0.3:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
-  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
-  dependencies:
-    concat-stream "^1.6.2"
-    debug "^2.6.9"
-    mkdirp "^0.5.4"
-    yauzl "^2.10.0"
-
-extract-zip@^2.0.0:
+extract-zip@^2.0.0, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -3536,7 +3532,7 @@ minizlib@^2.0.0, minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5:
+mkdirp@^0.5.1, mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -4318,7 +4314,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.1, readable-stream@^2.0.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5206,11 +5202,6 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
# Content only

Essa novidade é pra quem gosta de algo limpo, na hora de apresentar algo com o Notion.

Poderemos habilitar com o atalho `ctrl+esc` e ele irá esconder/mostrar

1. O header do Notion
2. O Título, ícone e as propriedades da página
3. O botão de ajuda do Notion

Tem sido bem útil pra mim e talvez seja útil pra mais alguém.

@ArthurLobopro @cleysonsilvame  o que acham?

# Readme.md

Aproveitei pra dar um tapinha no Readme, adicionando uma pequena navegação e gifs para exemplificar as `features`